### PR TITLE
Add Feature - Add "enable_ipam" option for private_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ module "my_cluster" {
 | <a name="input_backup_schedule_frequency"></a> [backup_schedule_frequency](#input_backup_schedule_frequency) | Backup schedule frequency in hours. | `number` | `24` | no |
 | <a name="input_backup_schedule_retention"></a> [backup_schedule_retention](#input_backup_schedule_retention) | Backup schedule retention in days. | `number` | `7` | no |
 | <a name="input_ha_enabled"></a> [ha_enabled](#input_ha_enabled) | Enable or disable high availability for the database instance. | `bool` | `false` | no |
-| <a name="input_private_network"></a> [private_network](#input_private_network) | Describes the private network you want to connect to your cluster. If not set, a public network will be provided. | ```object({ pn_id = string ip_net = string })``` | `null` | no |
+| <a name="input_private_network"></a> [private_network](#input_private_network) | Describes the private network you want to connect to your cluster. If not set, a public network will be provided. | ```object({ pn_id = string ip_net = optional(string) enable_ipam = optional(bool) })``` | `null` | no |
 | <a name="input_project_id"></a> [project_id](#input_project_id) | ID of the project the instance is associated with. Ressource will be created in the project set at the provider level if null. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input_region) | Region in which the instance should be created. Ressource will be created in the region set at the provider level if null. | `string` | `null` | no |
 | <a name="input_replica_enabled"></a> [replica_enabled](#input_replica_enabled) | Whether to create a read replica or not. | `bool` | `true` | no |
@@ -64,6 +64,7 @@ module "my_cluster" {
 |------|-------------|
 | <a name="output_cluster_certificate"></a> [cluster_certificate](#output_cluster_certificate) | PEM Certificate of the database instance. |
 | <a name="output_instance_id"></a> [instance_id](#output_instance_id) | ID of the Database Instance. |
+| <a name="output_instance_ip"></a> [instance_ip](#output_instance_ip) | Database instance IP |
 | <a name="output_load_balancer"></a> [load_balancer](#output_load_balancer) | List of load balancer endpoints of the database instance. |
 | <a name="output_replicate_pn"></a> [replicate_pn](#output_replicate_pn) | Private network attributes of the read replica. |
 | <a name="output_user_password"></a> [user_password](#output_user_password) | Password generated if non were given. |

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,9 @@ resource "scaleway_rdb_instance" "this" {
   dynamic "private_network" {
     for_each = var.private_network != null ? [1] : []
     content {
-      pn_id  = try(var.private_network.pn_id, null)
-      ip_net = try(var.private_network.ip_net, null)
+      pn_id       = try(var.private_network.pn_id, null)
+      ip_net      = try(var.private_network.ip_net, null)
+      enable_ipam = try(var.private_network.enable_ipam, false)
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "instance_id" {
   value       = scaleway_rdb_instance.this.id
 }
 
+output "instance_ip" {
+  description = "Database instance IP"
+  value       = scaleway_rdb_instance.this.private_network[*].ip
+}
+
 output "load_balancer" {
   description = "List of load balancer endpoints of the database instance."
   value       = scaleway_rdb_instance.this.load_balancer

--- a/variables.tf
+++ b/variables.tf
@@ -24,8 +24,9 @@ variable "node_type" {
 variable "private_network" {
   description = "Describes the private network you want to connect to your cluster. If not set, a public network will be provided."
   type = object({
-    pn_id  = string
-    ip_net = string
+    pn_id       = string
+    ip_net      = optional(string)
+    enable_ipam = optional(bool)
   })
   default = null
 }


### PR DESCRIPTION
- Add "enable_ipam" option in "private_network" variable
- Add Output to retrieve database instance IP
- Add "ip_net" and "enable_ipam" in "private_network" as optional because we must use one and not both
- Format documentation with tfdocs