### PR TITLE
Feature_add_settings_configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module "my_cluster" {
 | <a name="input_replica_enabled"></a> [replica_enabled](#input_replica_enabled) | Whether to create a read replica or not. | `bool` | `true` | no |
 | <a name="input_replica_private_network"></a> [replica_private_network](#input_replica_private_network) | Describes the private network you want to connect to your read replica. | ```object({ pn_id = string ip_net = string })``` | `null` | no |
 | <a name="input_replica_region"></a> [replica_region](#input_replica_region) | Region in which the replica should be created. Ressource will be created in the same region than the master if null. | `string` | `null` | no |
-| <a name="input_settings"></a> [settings](#input_settings) | Database settings configuration | `map(string)` | `{}` | no |
+| <a name="input_settings"></a> [settings](#input_settings) | Database settings configuration | `map(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags associated with the server and dedicated ip address. | `list(string)` | `[]` | no |
 | <a name="input_user_password"></a> [user_password](#input_user_password) | Password for the first user of the database instance. A random password will be generated if null. | `string` | `null` | no |
 | <a name="input_volume_size_in_gb"></a> [volume_size_in_gb](#input_volume_size_in_gb) | Volume size (in GB) when volume_type is set to bssd. Must be a multiple of 5000000000. | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module "my_cluster" {
 | <a name="input_replica_enabled"></a> [replica_enabled](#input_replica_enabled) | Whether to create a read replica or not. | `bool` | `true` | no |
 | <a name="input_replica_private_network"></a> [replica_private_network](#input_replica_private_network) | Describes the private network you want to connect to your read replica. | ```object({ pn_id = string ip_net = string })``` | `null` | no |
 | <a name="input_replica_region"></a> [replica_region](#input_replica_region) | Region in which the replica should be created. Ressource will be created in the same region than the master if null. | `string` | `null` | no |
+| <a name="input_settings"></a> [settings](#input_settings) | Database settings configuration | `map(string)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input_tags) | Tags associated with the server and dedicated ip address. | `list(string)` | `[]` | no |
 | <a name="input_user_password"></a> [user_password](#input_user_password) | Password for the first user of the database instance. A random password will be generated if null. | `string` | `null` | no |
 | <a name="input_volume_size_in_gb"></a> [volume_size_in_gb](#input_volume_size_in_gb) | Volume size (in GB) when volume_type is set to bssd. Must be a multiple of 5000000000. | `number` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,8 @@ resource "scaleway_rdb_instance" "this" {
       enable_ipam = try(var.private_network.enable_ipam, false)
     }
   }
+
+  settings = var.settings
 }
 
 resource "scaleway_rdb_read_replica" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "node_type" {
   type        = string
 }
 
+variable "settings" {
+  description = "Database settings configuration"
+  type        = map(string)
+  default     = {}
+}
+
 ## Network
 variable "private_network" {
   description = "Describes the private network you want to connect to your cluster. If not set, a public network will be provided."

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "node_type" {
 variable "settings" {
   description = "Database settings configuration"
   type        = map(string)
-  default     = {}
+  default     = null
 }
 
 ## Network


### PR DESCRIPTION
- Add "settings" variable
- Format documentation with tfdocs

I tested this feature locally and it's ok on my side.

I don't have integrate default Scaleway setting values because i suppose that these variable are different it depend of the instance size used.

We have two solutions:
- Integrate these default values inside default value of setting variable
- Leave use who use this module to set these values
- Ask on Scaleway terraform provider to skip default scaleway values if it's not present inside setting variable.

My point of view is that the third solution (terraform provider modification) is better.