### PR TITLE
Add possibility to set sbs(5k or 15k) volume types for rdb instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module "my_cluster" {
 | <a name="input_tags"></a> [tags](#input_tags) | Tags associated with the server and dedicated ip address. | `list(string)` | `[]` | no |
 | <a name="input_user_password"></a> [user_password](#input_user_password) | Password for the first user of the database instance. A random password will be generated if null. | `string` | `null` | no |
 | <a name="input_volume_size_in_gb"></a> [volume_size_in_gb](#input_volume_size_in_gb) | Volume size (in GB) when volume_type is set to bssd. Must be a multiple of 5000000000. | `number` | `null` | no |
-| <a name="input_volume_type"></a> [volume_type](#input_volume_type) | Type of volume where data are stored (bssd or lssd). | `string` | `"lssd"` | no |
+| <a name="input_volume_type"></a> [volume_type](#input_volume_type) | Type of volume where data are stored (bssd, lssd, sbs_5k or sbs_15k). | `string` | `"lssd"` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,13 +45,13 @@ variable "enable_encryption" {
 }
 
 variable "volume_type" {
-  description = "Type of volume where data are stored (bssd or lssd)."
+  description = "Type of volume where data are stored (bssd, lssd, sbs_5k or sbs_15k)."
   type        = string
   default     = "lssd"
 
   validation {
-    condition     = contains(["bssd", "lssd"], var.volume_type)
-    error_message = "Volumes can only be one of 'bssd' or 'lssd'."
+    condition     = contains(["bssd", "lssd", "sbs_5k", "sbs_15k"], var.volume_type)
+    error_message = "Volumes can only be one of 'bssd', 'lssd', 'sbs_5k' or 'sbs_15k'."
   }
 }
 


### PR DESCRIPTION
It's possible to set sbs_5k or sbs_15k for volume type rdb instance since the version 2.41.0 of terraform scaleway provider : https://registry.terraform.io/providers/scaleway/scaleway/2.41.0/docs/resources/rdb_instance